### PR TITLE
Fix navbar logo overflow, enhance reviews, and stabilize hero heading

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,8 @@
-const withBundleAnalyzer = require('@next/bundle-analyzer')({
+import bundleAnalyzer from '@next/bundle-analyzer';
+
+const withBundleAnalyzer = bundleAnalyzer({
   enabled: process.env.ANALYZE === 'true',
-})
+});
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -20,7 +22,7 @@ const nextConfig = {
   },
   // Add this to allow cross-origin requests during development from your local network IP
   experimental: {
-    allowedDevOrigins: ["http://10.168.0.3:3000"],
+    allowedDevOrigins: ['http://10.168.0.3:3000'],
   },
   // Disable ESLint during builds as it conflicts with flat config
   eslint: {
@@ -28,4 +30,4 @@ const nextConfig = {
   },
 };
 
-module.exports = withBundleAnalyzer(nextConfig);
+export default withBundleAnalyzer(nextConfig);

--- a/src/app/api/chat-research/route.ts
+++ b/src/app/api/chat-research/route.ts
@@ -65,7 +65,7 @@ export async function POST(req: NextRequest) {
   // Check rate limit
   // Correct way to get IP in Vercel Edge/Node.js environments
   const ip = req.headers.get('x-forwarded-for') ?? req.headers.get('x-real-ip') ?? '127.0.0.1';
-  const { success, limit, remaining, reset } = await ratelimit.limit(ip);
+  const { success } = await ratelimit.limit(ip);
 
   if (!success) {
     return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 });
@@ -74,7 +74,6 @@ export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
     const userMessage = body.message;
-    const history = body.history || []; // Expecting history from frontend
 
     if (!userMessage || typeof userMessage !== 'string') {
       return NextResponse.json({ error: 'Invalid message format' }, { status: 400 });

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,5 +1,4 @@
 // This is now a Server Component by default (no "use client")
-import Link from "next/link"; // Keep Link if needed for static parts
 import BlogListClient from "@/components/BlogListClient"; // Import the Client Component
 import { getSortedPostsData } from "@/lib/posts"; // Import the server-side data fetching function
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
-import Link from "next/link";
 import Script from "next/script"; // Import the Script component
 import { Analytics } from "@vercel/analytics/react";
 import Navigation from "@/components/Navigation";
@@ -75,7 +74,12 @@ export default function RootLayout({
         />
         <FormLoggerProvider>
           <Navigation />
-          <main className="min-h-screen pt-20">{children}</main>
+          <main
+            className="min-h-screen"
+            style={{ paddingTop: "var(--nav-total-height, 0px)" }}
+          >
+            {children}
+          </main>
 
           <ChatBot />
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -133,12 +133,13 @@ function ServiceJsonLd() {
 export default function Home() {
   // Data defined in Server Component
   const testimonials: Testimonial[] = [
-     {
+    {
       text: "I am beyond impressed with the service I received from Brandon at LB Computer Help. He went above and beyond to find the perfect router for our office that could prioritize our fax machine and phones. Since the new setup, we've already noticed a significant improvement in call quality.",
       name: "Alondra S.",
       role: "Office Manager",
       image: "/images/testimonials/client1.jpg",
       source: "google",
+      rating: 5,
     },
     {
       text: "As a boutique law firm handling sensitive client information daily, finding reliable IT support is critical. When we experienced a server failure before a major trial, Brandon responded immediately. The recovery was completed ahead of schedule, allowing our legal team to access critical documents well before our court deadline.",
@@ -146,6 +147,7 @@ export default function Home() {
       role: "Visionary Law Group",
       image: "/images/testimonials/client2.jpg",
       source: "yelp",
+      rating: 5,
     },
     {
       text: "Brandon was super kind and helpful! He fixed my printer issues which I was having for about 3 weeks in just 30 minutes! He not only was super helpful but also walked me through the process so I can fix it on my own next time.",
@@ -153,6 +155,7 @@ export default function Home() {
       role: "Residential Client",
       image: "/images/testimonials/client3.jpg",
       source: "facebook",
+      rating: 5,
     },
     {
       text: "I had such a great experience with LB Computer Help! My laptop was running super slow, and I needed it fixed ASAP. They were able to diagnose the issue quickly and optimize my system, making it run like new again. The service was fast, professional, and hassle-free.",
@@ -160,12 +163,14 @@ export default function Home() {
       role: "Small Business Owner",
       image: "/images/testimonials/client4.jpg",
       source: "nextdoor",
+      rating: 5,
     },
     {
       text: "I'm so impressed with their data recovery service. After my hard drive failed, I thought all my files were gone for good, but they managed to recover everything quickly. I'm so relieved to have my data back.",
       name: "Luke T.",
       role: "Photographer",
       source: "thumbtack",
+      rating: 5,
     },
   ];
 

--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -47,6 +47,7 @@ export default function HomePageClient({ services, testimonials }: HomePageClien
     setIsLoaded(true);
   }, []);
 
+
   // Filter services based on selected category
   const filteredServices =
     serviceFilter === "all"
@@ -69,7 +70,10 @@ export default function HomePageClient({ services, testimonials }: HomePageClien
       className={`min-h-screen font-sans transition-opacity duration-1000 ${isLoaded ? "opacity-100" : "opacity-0"}`}
     >
       {/* Hero Section */}
-      <section className="relative h-screen min-h-[800px] flex items-center bg-gradient-to-r from-blue-900 via-blue-800 to-blue-700">
+      <section
+        className="relative min-h-screen md:min-h-[800px] flex items-start pb-16 bg-gradient-to-r from-blue-900 via-blue-800 to-blue-700"
+        style={{ paddingTop: "calc(var(--nav-total-height, 0px) + 80px)" }}
+      >
         <div className="absolute inset-0 overflow-hidden">
           <div
             className="absolute inset-0 bg-cover bg-center"
@@ -87,17 +91,18 @@ export default function HomePageClient({ services, testimonials }: HomePageClien
             <div className="text-white">
               <FadeIn direction="up">
                 <h1 className="text-5xl md:text-6xl lg:text-7xl font-bold leading-tight mb-5">
-                  <span className="text-white">LB</span>
-                  <span className="text-orange-400"> Computer</span>
-                  <span className="text-white"> Help</span>
-                  <br />
+                  <span className="block whitespace-nowrap">
+                    <span className="text-white">LB</span>
+                    <span className="text-orange-400"> Computer</span>
+                    <span className="text-white"> Help</span>
+                  </span>
                   <TypewriterEffect
                     texts={[
                       "Expert IT Support in Long Beach\u00A0",
                       "Computer Services for Businesses & Homes\u00A0",
                       "Reliable Network Solutions\u00A0",
                     ]}
-                    className="text-3xl md:text-4xl lg:text-5xl text-white"
+                    className="block mt-2 text-3xl md:text-4xl lg:text-5xl text-white"
                   />
                 </h1>
                 <p className="text-lg md:text-xl text-gray-200 mb-8">

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -125,6 +125,33 @@ export default function Navigation() {
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
+  // Expose combined navigation and emergency banner height as a CSS variable
+  useEffect(() => {
+    const nav = document.getElementById("navbar");
+    const emergency = document.getElementById("emergency-banner");
+
+    const updateOffset = () => {
+      const totalHeight =
+        (nav?.offsetHeight || 0) + (emergency?.offsetHeight || 0);
+      document.documentElement.style.setProperty(
+        "--nav-total-height",
+        `${totalHeight}px`
+      );
+    };
+
+    updateOffset();
+
+    const resizeObserver = new ResizeObserver(updateOffset);
+    if (nav) resizeObserver.observe(nav);
+    if (emergency) resizeObserver.observe(emergency);
+    window.addEventListener("resize", updateOffset);
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener("resize", updateOffset);
+    };
+  }, [isEmergencyVisible]);
+
   // Force consistent style regardless of page
   const navBackgroundColor = () => {
     if (isHomePage) {
@@ -180,9 +207,15 @@ export default function Navigation() {
   /* Admin status is already handled in the component */
 
   return (
-    <div className="fixed top-0 left-0 right-0 z-40 transition-all duration-300">
+    <div
+      id="main-navigation"
+      className="fixed top-0 left-0 right-0 z-40 transition-all duration-300"
+    >
       {isEmergencyVisible && (
-        <div className="bg-gradient-to-r from-blue-800 via-blue-700 to-blue-600 py-1">
+        <div
+          id="emergency-banner"
+          className="bg-gradient-to-r from-blue-800 via-blue-700 to-blue-600 py-1"
+        >
           <div className="container mx-auto px-4">
             <div className="flex items-center justify-between">
               <div className="flex items-center">
@@ -257,9 +290,12 @@ export default function Navigation() {
         </div>
       )}
 
-      <div className={`${navBackgroundColor()} py-2`}>
+      <div id="navbar" className={`${navBackgroundColor()} py-3 md:py-4`}>
         <div className="container mx-auto px-4 flex justify-between items-center">
-          <Link href="/" className={`font-bold text-xl ${textColor()}`}>
+          <Link
+            href="/"
+            className={`font-bold text-lg sm:text-xl ${textColor()} whitespace-nowrap flex-shrink-0`}
+          >
             LB Computer Help
           </Link>
           <nav className="hidden md:flex items-center gap-6">

--- a/src/components/ResidentialBusinessClientPage.tsx
+++ b/src/components/ResidentialBusinessClientPage.tsx
@@ -1,7 +1,6 @@
 "use client"; // Mark this as a Client Component
 
 import { useState, useEffect } from "react";
-import Image from "next/image";
 import Link from "next/link";
 import FadeIn from "@/components/FadeIn";
 import FloatingShapes from "@/components/FloatingShapes";
@@ -10,7 +9,6 @@ import ServiceCard from "@/components/ServicesCard";
 import TestimonialCarousel, {
   Testimonial,
 } from "@/components/TestimonialCarousel";
-import RevealText from "@/components/RevealText";
 
 // Declare gtag_report_conversion function for TypeScript
 declare global {
@@ -31,12 +29,13 @@ export default function ResidentialBusinessClientPage(/* props: ResidentialBusin
 
   // Selected Safe Testimonials
   const testimonials: Testimonial[] = [
-     {
+    {
       text: "I am beyond impressed with the service I received from Brandon at LB Computer Help. He went above and beyond to find the perfect router for our office that could prioritize our fax machine and phones. Since the new setup, we've already noticed a significant improvement in call quality.",
       name: "Alondra S.",
       role: "Office Manager",
       image: "/images/testimonials/client1.jpg",
       source: "google",
+      rating: 5,
     },
     {
       text: "I had such a great experience with LB Computer Help! My laptop was running super slow, and I needed it fixed ASAP. They were able to diagnose the issue quickly and optimize my system, making it run like new again. The service was fast, professional, and hassle-free.",
@@ -44,6 +43,7 @@ export default function ResidentialBusinessClientPage(/* props: ResidentialBusin
       role: "Small Business Owner",
       image: "/images/testimonials/client4.jpg",
       source: "nextdoor",
+      rating: 5,
     },
     // Add more compliant testimonials if available
   ];

--- a/src/components/TestimonialCarousel.tsx
+++ b/src/components/TestimonialCarousel.tsx
@@ -9,6 +9,7 @@ export interface Testimonial {
   role: string;
   image?: string;
   source?: "google" | "yelp" | "facebook" | "thumbtack" | "nextdoor";
+  rating?: number;
 }
 
 interface TestimonialCarouselProps {
@@ -148,6 +149,24 @@ export default function TestimonialCarousel({
                   />
                 </svg>
               </div>
+            )}
+          </div>
+        )}
+
+        {testimonials[current].rating && (
+          <div className="flex justify-center mb-4">
+            {Array.from({ length: Math.round(testimonials[current].rating) }).map(
+              (_, i) => (
+                <svg
+                  key={i}
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  className="w-5 h-5 text-yellow-400"
+                >
+                  <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.286 3.97a1 1 0 00.95.69h4.175c.969 0 1.371 1.24.588 1.81l-3.38 2.455a1 1 0 00-.364 1.118l1.287 3.971c.3.921-.755 1.688-1.54 1.118l-3.381-2.455a1 1 0 00-1.175 0l-3.38 2.455c-.786.57-1.84-.197-1.54-1.118l1.287-3.97a1 1 0 00-.364-1.119L2.05 9.397c-.783-.57-.38-1.81.588-1.81h4.175a1 1 0 00.95-.69l1.286-3.97z" />
+                </svg>
+              ),
             )}
           </div>
         )}


### PR DESCRIPTION
## Summary
- expose combined navbar and emergency-banner height as `--nav-total-height`
- pad pages and hero section using this variable so the LB Computer Help headline never hides behind fixed bars
- observe nav and banner with `ResizeObserver` and add extra hero padding so the heading stays visible even when text grows

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68956b7b6c74832fbf23d095289056f0