### PR TITLE
Refactor navigation wrapper into sticky header

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,8 +2,7 @@ import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
 import Script from "next/script"; // Import the Script component
 import { Analytics } from "@vercel/analytics/react";
-import UtilityBar from "@/components/UtilityBar";
-import MainNav from "@/components/MainNav";
+import Navigation from "@/components/Navigation";
 import ChatBot from "@/components/ChatBot";
 import FooterMain from "@/components/footer/FooterMain"; // Import the new main footer component
 import { FormLoggerProvider } from "@/components/FormLogger";
@@ -74,13 +73,7 @@ export default function RootLayout({
           }}
         />
         <FormLoggerProvider>
-          <header
-            id="site-header"
-            className="sticky top-0 z-50 bg-white/80 backdrop-blur"
-          >
-            <UtilityBar />
-            <MainNav />
-          </header>
+          <Navigation />
           <main className="min-h-screen">{children}</main>
 
           <ChatBot />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import UtilityBar from "./UtilityBar";
+import MainNav from "./MainNav";
+
+export default function Navigation() {
+  return (
+    <header
+      id="site-header"
+      className="sticky top-0 z-50 bg-white/80 backdrop-blur"
+    >
+      <UtilityBar />
+      <MainNav />
+    </header>
+  );
+}
+


### PR DESCRIPTION
## Summary
- create a dedicated Navigation component that wraps the utility bar and main nav in a sticky header
- update the root layout to consume the new header so hero content sits naturally beneath it

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3387ecef4832fa88fc9bb4ace14e8