### PR TITLE
Refine navigation spacing for sticky header

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -64,6 +64,7 @@ html {
   /* Core colors */
   --background: #ffffff;
   --foreground: #171717;
+  --site-header-height: 0px;
 
   /* Primary blue colors */
   --primary: #2563eb;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,8 +2,7 @@ import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
 import Script from "next/script"; // Import the Script component
 import { Analytics } from "@vercel/analytics/react";
-import UtilityBar from "@/components/UtilityBar";
-import MainNav from "@/components/MainNav";
+import Navigation from "@/components/Navigation";
 import ChatBot from "@/components/ChatBot";
 import FooterMain from "@/components/footer/FooterMain"; // Import the new main footer component
 import { FormLoggerProvider } from "@/components/FormLogger";
@@ -74,14 +73,10 @@ export default function RootLayout({
           }}
         />
         <FormLoggerProvider>
-          <header
-            id="site-header"
-            className="sticky top-0 z-50 bg-white/80 backdrop-blur"
-          >
-            <UtilityBar />
-            <MainNav />
-          </header>
-          <main className="min-h-screen">{children}</main>
+          <Navigation />
+          <main className="min-h-screen pt-[var(--site-header-height,0px)]">
+            {children}
+          </main>
 
           <ChatBot />
 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import UtilityBar from "./UtilityBar";
+import MainNav from "./MainNav";
+
+export default function Navigation() {
+  const headerRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const headerElement = headerRef.current;
+    if (!headerElement) return;
+
+    const root = document.documentElement;
+
+    const updateHeaderOffset = () => {
+      const height = headerElement.offsetHeight;
+      root.style.setProperty("--site-header-height", `${height}px`);
+      root.style.scrollPaddingTop = `${height}px`;
+    };
+
+    const handleResize = () => {
+      window.requestAnimationFrame(updateHeaderOffset);
+    };
+
+    updateHeaderOffset();
+
+    let resizeObserver: ResizeObserver | null = null;
+
+    if (typeof ResizeObserver !== "undefined") {
+      resizeObserver = new ResizeObserver(() => handleResize());
+      resizeObserver.observe(headerElement);
+    } else {
+      window.addEventListener("resize", handleResize);
+    }
+
+    return () => {
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", handleResize);
+      root.style.removeProperty("--site-header-height");
+      root.style.scrollPaddingTop = "";
+    };
+  }, []);
+
+  return (
+    <header
+      ref={headerRef}
+      id="site-header"
+      className="sticky top-0 z-50 bg-white/80 backdrop-blur"
+    >
+      <UtilityBar />
+      <MainNav />
+    </header>
+  );
+}
+


### PR DESCRIPTION
## Summary
- create a dedicated Navigation component that wraps the utility bar and main nav in a sticky header
- update the root layout to consume the new header so hero content sits naturally beneath it
- measure the sticky header height at runtime to set CSS variables that pad page content and adjust scroll padding for anchors

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3387ecef4832fa88fc9bb4ace14e8