### PR TITLE
Fix sticky header safe-area gap

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -64,6 +64,7 @@ html {
   /* Core colors */
   --background: #ffffff;
   --foreground: #171717;
+  --site-header-height: 0px;
 
   /* Primary blue colors */
   --primary: #2563eb;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,8 +2,7 @@ import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
 import Script from "next/script"; // Import the Script component
 import { Analytics } from "@vercel/analytics/react";
-import UtilityBar from "@/components/UtilityBar";
-import MainNav from "@/components/MainNav";
+import Navigation from "@/components/Navigation";
 import ChatBot from "@/components/ChatBot";
 import FooterMain from "@/components/footer/FooterMain"; // Import the new main footer component
 import { FormLoggerProvider } from "@/components/FormLogger";
@@ -74,14 +73,10 @@ export default function RootLayout({
           }}
         />
         <FormLoggerProvider>
-          <header
-            id="site-header"
-            className="sticky top-0 z-50 bg-white/80 backdrop-blur"
-          >
-            <UtilityBar />
-            <MainNav />
-          </header>
-          <main className="min-h-screen">{children}</main>
+          <Navigation />
+          <main className="min-h-screen">
+            {children}
+          </main>
 
           <ChatBot />
 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import UtilityBar from "./UtilityBar";
+import MainNav from "./MainNav";
+
+export default function Navigation() {
+  return (
+    <header
+      id="site-header"
+      className="sticky top-0 z-50 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60"
+      style={{ paddingTop: "env(safe-area-inset-top, 0px)" }}
+    >
+      <UtilityBar />
+      <MainNav />
+    </header>
+  );
+}
+


### PR DESCRIPTION
## Summary
- simplify the Navigation header to rely on sticky positioning, drop runtime height measurement, and pad for the mobile safe area
- remove the layout's nav-height padding so the hero content meets the sticky header without leaving a dark band

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3387ecef4832fa88fc9bb4ace14e8