### PR TITLE
Refine header spacing for multi-line utility bar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -64,6 +64,8 @@ html {
   /* Core colors */
   --background: #ffffff;
   --foreground: #171717;
+  --site-header-height: 0px;
+  --site-header-scroll-offset: 0px;
 
   /* Primary blue colors */
   --primary: #2563eb;
@@ -144,6 +146,11 @@ body {
   color: var(--gray-800);
   font-family: var(--font-sans, Arial, Helvetica, sans-serif);
   overflow-x: hidden;
+  scroll-padding-top: var(--site-header-scroll-offset, 0px);
+}
+
+.header-offset {
+  padding-top: var(--site-header-scroll-offset, 0px);
 }
 
 .hero-title {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,8 +2,7 @@ import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
 import Script from "next/script"; // Import the Script component
 import { Analytics } from "@vercel/analytics/react";
-import UtilityBar from "@/components/UtilityBar";
-import MainNav from "@/components/MainNav";
+import Navigation from "@/components/Navigation";
 import ChatBot from "@/components/ChatBot";
 import FooterMain from "@/components/footer/FooterMain"; // Import the new main footer component
 import { FormLoggerProvider } from "@/components/FormLogger";
@@ -74,14 +73,10 @@ export default function RootLayout({
           }}
         />
         <FormLoggerProvider>
-          <header
-            id="site-header"
-            className="sticky top-0 z-50 bg-white/80 backdrop-blur"
-          >
-            <UtilityBar />
-            <MainNav />
-          </header>
-          <main className="min-h-screen">{children}</main>
+          <Navigation />
+          <main className="min-h-screen">
+            {children}
+          </main>
 
           <ChatBot />
 

--- a/src/components/ContactPageClient.tsx
+++ b/src/components/ContactPageClient.tsx
@@ -67,7 +67,7 @@ export default function ContactPageClient() {
       className={`min-h-screen bg-background text-foreground font-sans transition-opacity duration-1000 ${isLoaded ? "opacity-100" : "opacity-0"}`}
     >
       {/* Contact Banner */}
-      <div className="relative py-24 bg-gradient-to-r from-blue-800 to-blue-600 text-white">
+      <div className="header-offset relative py-24 bg-gradient-to-r from-blue-800 to-blue-600 text-white">
         <div className="absolute inset-0 bg-black opacity-30"></div>
         <div
           className="absolute inset-0 bg-cover bg-center"

--- a/src/components/EmergencyPageClient.tsx
+++ b/src/components/EmergencyPageClient.tsx
@@ -16,7 +16,7 @@ export default function EmergencyPageClient() {
       className={`min-h-screen bg-background text-foreground font-sans transition-opacity duration-1000 ${isLoaded ? "opacity-100" : "opacity-0"}`}
     >
       {/* Emergency Banner */}
-      <div className="relative py-24 bg-gradient-to-r from-red-700 to-red-500 text-white">
+      <div className="header-offset relative py-24 bg-gradient-to-r from-red-700 to-red-500 text-white">
         <div className="absolute inset-0 bg-black opacity-30"></div>
         <div className="relative z-10 container mx-auto px-4 md:px-8 text-center">
           <h1 className="text-4xl md:text-5xl font-bold mb-4">

--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -69,7 +69,7 @@ export default function HomePageClient({ services, testimonials }: HomePageClien
       className={`min-h-screen font-sans transition-opacity duration-1000 ${isLoaded ? "opacity-100" : "opacity-0"}`}
     >
       {/* Hero Section */}
-      <section className="relative h-screen min-h-[800px] flex items-center bg-gradient-to-r from-blue-900 via-blue-800 to-blue-700">
+      <section className="header-offset relative h-screen min-h-[800px] flex items-center bg-gradient-to-r from-blue-900 via-blue-800 to-blue-700">
         <div className="absolute inset-0 overflow-hidden">
           <div
             className="absolute inset-0 bg-cover bg-center"

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import UtilityBar from "./UtilityBar";
+UtilityBar from "./UtilityBar";
 import MainNav from "./MainNav";
 
 export default function Navigation() {
   return (
-    <header id="site-header" className="sticky top-0 z-50 bg-white/80 backdrpop-blur">
+    <header id="site-header" className="sticky top-0 z-50 bg-white/80 backdrop-blur">
       <UtilityBar />
       <MainNav />
     </header>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import UtilityBar from "./UtilityBar";
+import MainNav from "./MainNav";
+
+const isBrowser = typeof window !== "undefined";
+
+export default function Navigation() {
+  const headerRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!isBrowser) return;
+
+    const headerEl = headerRef.current;
+    if (!headerEl) return;
+
+    const root = document.documentElement;
+    const body = document.body;
+
+    const updateHeaderMeasurements = () => {
+      const height = headerEl.offsetHeight;
+      const clampedHeight = Math.max(0, Math.round(height));
+
+      root.style.setProperty("--site-header-height", `${clampedHeight}px`);
+      root.style.setProperty(
+        "--site-header-scroll-offset",
+        `${clampedHeight + 16}px`,
+      );
+      body.style.scrollPaddingTop = `${clampedHeight + 16}px`;
+    };
+
+    updateHeaderMeasurements();
+
+    let resizeObserver: ResizeObserver | undefined;
+
+    if ("ResizeObserver" in window) {
+      resizeObserver = new ResizeObserver(() => {
+        updateHeaderMeasurements();
+      });
+      resizeObserver.observe(headerEl);
+    }
+
+    window.addEventListener("resize", updateHeaderMeasurements);
+
+    return () => {
+      window.removeEventListener("resize", updateHeaderMeasurements);
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      }
+      root.style.removeProperty("--site-header-height");
+      root.style.removeProperty("--site-header-scroll-offset");
+      body.style.removeProperty("scroll-padding-top");
+    };
+  }, []);
+
+  return (
+    <header
+      ref={headerRef}
+      id="site-header"
+      className="sticky top-0 z-50 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60"
+      style={{ paddingTop: "env(safe-area-inset-top, 0px)" }}
+    >
+      <UtilityBar />
+      <MainNav />
+    </header>
+  );
+}
+

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,69 +1,13 @@
 "use client";
 
-import { useEffect, useRef } from "react";
 import UtilityBar from "./UtilityBar";
 import MainNav from "./MainNav";
 
-const isBrowser = typeof window !== "undefined";
-
 export default function Navigation() {
-  const headerRef = useRef<HTMLElement | null>(null);
-
-  useEffect(() => {
-    if (!isBrowser) return;
-
-    const headerEl = headerRef.current;
-    if (!headerEl) return;
-
-    const root = document.documentElement;
-    const body = document.body;
-
-    const updateHeaderMeasurements = () => {
-      const height = headerEl.offsetHeight;
-      const clampedHeight = Math.max(0, Math.round(height));
-
-      root.style.setProperty("--site-header-height", `${clampedHeight}px`);
-      root.style.setProperty(
-        "--site-header-scroll-offset",
-        `${clampedHeight + 16}px`,
-      );
-      body.style.scrollPaddingTop = `${clampedHeight + 16}px`;
-    };
-
-    updateHeaderMeasurements();
-
-    let resizeObserver: ResizeObserver | undefined;
-
-    if ("ResizeObserver" in window) {
-      resizeObserver = new ResizeObserver(() => {
-        updateHeaderMeasurements();
-      });
-      resizeObserver.observe(headerEl);
-    }
-
-    window.addEventListener("resize", updateHeaderMeasurements);
-
-    return () => {
-      window.removeEventListener("resize", updateHeaderMeasurements);
-      if (resizeObserver) {
-        resizeObserver.disconnect();
-      }
-      root.style.removeProperty("--site-header-height");
-      root.style.removeProperty("--site-header-scroll-offset");
-      body.style.removeProperty("scroll-padding-top");
-    };
-  }, []);
-
   return (
-    <header
-      ref={headerRef}
-      id="site-header"
-      className="sticky top-0 z-50 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60"
-      style={{ paddingTop: "env(safe-area-inset-top, 0px)" }}
-    >
+    <header id="site-header" className="sticky top-0 z-50 bg-white/80 backdrpop-blur">
       <UtilityBar />
       <MainNav />
     </header>
   );
 }
-

--- a/src/components/ResidentialBusinessClientPage.tsx
+++ b/src/components/ResidentialBusinessClientPage.tsx
@@ -111,7 +111,7 @@ export default function ResidentialBusinessClientPage(/* props: ResidentialBusin
       className={`min-h-screen font-sans transition-opacity duration-1000 ${isLoaded ? "opacity-100" : "opacity-0"}`}
     >
       {/* Hero Section - Revised */}
-      <section className="relative h-[70vh] min-h-[600px] flex items-center bg-gradient-to-r from-blue-900 via-blue-800 to-blue-700">
+      <section className="header-offset relative h-[70vh] min-h-[600px] flex items-center bg-gradient-to-r from-blue-900 via-blue-800 to-blue-700">
         <div className="absolute inset-0 overflow-hidden">
           <div className="absolute inset-0 bg-black opacity-30"></div>
            <div

--- a/src/components/ServicesPageClient.tsx
+++ b/src/components/ServicesPageClient.tsx
@@ -43,7 +43,7 @@ export default function ServicesPageClient({ servicesDetail }: ServicesPageClien
       className={`min-h-screen bg-background text-foreground font-sans transition-opacity duration-1000 ${isLoaded ? "opacity-100" : "opacity-0"}`}
     >
       {/* Header Banner (Consider moving this to the Server Component if static) */}
-      <div className="relative py-24 bg-gradient-to-r from-blue-800 to-blue-600 text-white">
+      <div className="header-offset relative py-24 bg-gradient-to-r from-blue-800 to-blue-600 text-white">
         <div className="absolute inset-0 bg-black opacity-30"></div>
         <div className="relative z-10 container mx-auto px-4 md:px-8 text-center">
           <h1 className="text-4xl md:text-5xl font-bold mb-4">Our IT Services in Long Beach</h1>


### PR DESCRIPTION
## Summary
- restore a client-side header measurement to keep a CSS variable and scroll padding aligned with the sticky navigation height plus a small breathing room
- expose a reusable .header-offset helper and apply it to hero banners so page intros clear the nav stack when the utility bar wraps or expands
- update global scroll padding so in-page anchor jumps honor the dynamic header height without guessing at magic numbers

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3387ecef4832fa88fc9bb4ace14e8